### PR TITLE
feat(retry-forever): allow option to retry forever

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -1,8 +1,10 @@
 var RetryOperation = require('./retry_operation');
 
 exports.operation = function(options) {
+  var retryForever = false;
+  if (options && options.forever === true) retryForever = true;
   var timeouts = exports.timeouts(options);
-  return new RetryOperation(timeouts);
+  return new RetryOperation(timeouts, retryForever);
 };
 
 exports.timeouts = function(options) {

--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -27,6 +27,8 @@ RetryOperation.prototype.retry = function(err) {
   var timeout = this._timeouts.shift();
   if (timeout === undefined) {
     if (this._cachedTimeouts) {
+      // retry forever, only keep last error
+      this._errors.splice(this._errors.length - 1, this._errors.length);
       this._timeouts = this._cachedTimeouts.slice(0);
       timeout = this._timeouts.shift();
     } else {

--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -1,4 +1,4 @@
-function RetryOperation(timeouts) {
+function RetryOperation(timeouts, retryForever) {
   this._timeouts = timeouts;
   this._fn = null;
   this._errors = [];
@@ -6,6 +6,10 @@ function RetryOperation(timeouts) {
   this._operationTimeout = null;
   this._operationTimeoutCb = null;
   this._timeout = null;
+
+  if (!!retryForever) {
+    this._cachedTimeouts = this._timeouts.slice(0);
+  }
 }
 module.exports = RetryOperation;
 
@@ -22,7 +26,12 @@ RetryOperation.prototype.retry = function(err) {
 
   var timeout = this._timeouts.shift();
   if (timeout === undefined) {
-    return false;
+    if (this._cachedTimeouts) {
+      this._timeouts = this._cachedTimeouts.slice(0);
+      timeout = this._timeouts.shift();
+    } else {
+      return false;
+    }
   }
 
   this._attempts++;

--- a/test/integration/test-retry-operation.js
+++ b/test/integration/test-retry-operation.js
@@ -78,3 +78,29 @@ var retry = require(common.dir.lib + '/retry');
 
   fn();
 })();
+
+(function testRetryForever() {
+  var error = new Error('some error');
+  var operation = retry.operation({ retries: 3, forever: true });
+  var attempts = 0;
+
+  var finalCallback = fake.callback('finalCallback');
+  fake.expectAnytime(finalCallback);
+
+  var fn = function() {
+    operation.attempt(function(currentAttempt) {
+      attempts++;
+      assert.equal(currentAttempt, attempts);
+      if (attempts !== 6 && operation.retry(error)) {
+        return;
+      }
+
+      assert.strictEqual(attempts, 6);
+      assert.strictEqual(operation.attempts(), attempts);
+      assert.strictEqual(operation.mainError(), error);
+      finalCallback();
+    });
+  };
+
+  fn();
+})();


### PR DESCRIPTION
This provides a new option to retry to conditionally allow retrying
forever. I've chosen not to override the 'retries' options with
e.g. Infinity so that the user can still have a modicum of control
over the retry process in this particular scenario.

**NOTE**: I have intentionally left ```this._errors``` alone pending conversation. Obviously in a "forever" loop that array could grow to be quite large. If you agree that this should be incorporated in the first place, do you think it's safe to slice the errors array to the last error on each forever "wraparound"?