### PR TITLE
Fix error when using `cb` in `timeoutOps`

### DIFF
--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -60,7 +60,7 @@ RetryOperation.prototype.retry = function(err) {
         self._operationTimeoutCb(self._attempts);
       }, self._operationTimeout);
 
-      if (this._options.unref) {
+      if (self._options.unref) {
           self._timeout.unref();
       }
     }


### PR DESCRIPTION
Fix for https://github.com/tim-kos/node-retry/issues/36
