### PR TITLE
supports maxRetryTime for retryOperation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Creates a new `RetryOperation` object. `options` is the same as `retry.timeouts(
 
 * `forever`: Whether to retry forever, defaults to `false`.
 * `unref`: Whether to [unref](https://nodejs.org/api/timers.html#timers_unref) the setTimeout's, defaults to `false`.
-* `maxRetryTime`: The number of milliseconds maximum amount to retry the operation. Default is `Infinity`  
+* `maxRetryTime`: The maximum time (in milliseconds) that the retried operation is allowed to run. Default is `Infinity`.  
 
 ### retry.timeouts([options])
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Creates a new `RetryOperation` object. `options` is the same as `retry.timeouts(
 
 * `forever`: Whether to retry forever, defaults to `false`.
 * `unref`: Whether to [unref](https://nodejs.org/api/timers.html#timers_unref) the setTimeout's, defaults to `false`.
+* `maxRetryTime`: The number of milliseconds maximum amount to retry the operation. Default is `Infinity`  
 
 ### retry.timeouts([options])
 

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -4,7 +4,8 @@ exports.operation = function(options) {
   var timeouts = exports.timeouts(options);
   return new RetryOperation(timeouts, {
       forever: options && options.forever,
-      unref: options && options.unref
+      unref: options && options.unref,
+      maxRetryTime: options && options.maxRetryTime
   });
 };
 

--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -38,7 +38,8 @@ RetryOperation.prototype.retry = function(err) {
   if (!err) {
     return false;
   }
-  if (err && Date.now() - this._operationStart > this._maxRetryTime) {
+  var currentTime = new Date().getTime();
+  if (err && currentTime - this._operationStart >= this._maxRetryTime) {
     this._errors.unshift(new Error('RetryOperation timeout occurred'));
     return false;
   }
@@ -100,7 +101,7 @@ RetryOperation.prototype.attempt = function(fn, timeoutOps) {
     }, self._operationTimeout);
   }
 
-  this._operationStart = Date.now();
+  this._operationStart = new Date().getTime();
 
   this._fn(this._attempts);
 };

--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -39,8 +39,8 @@ RetryOperation.prototype.retry = function(err) {
     return false;
   }
   if (err && Date.now() - this._operationStart > this._maxRetryTime) {
-      this._errors.unshift(new Error('RetryOperation timeout occurred'));
-      return false;
+    this._errors.unshift(new Error('RetryOperation timeout occurred'));
+    return false;
   }
 
   this._errors.push(err);

--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -6,12 +6,14 @@ function RetryOperation(timeouts, options) {
 
   this._timeouts = timeouts;
   this._options = options || {};
+  this._maxRetryTime = options && options.maxRetryTime || Infinity;
   this._fn = null;
   this._errors = [];
   this._attempts = 1;
   this._operationTimeout = null;
   this._operationTimeoutCb = null;
   this._timeout = null;
+  this._operationStart = null;
 
   if (this._options.forever) {
     this._cachedTimeouts = this._timeouts.slice(0);
@@ -35,6 +37,10 @@ RetryOperation.prototype.retry = function(err) {
 
   if (!err) {
     return false;
+  }
+  if (err && Date.now() - this._operationStart > this._maxRetryTime) {
+      this._errors.unshift(new Error('RetryOperation timeout occurred'));
+      return false;
   }
 
   this._errors.push(err);
@@ -93,6 +99,8 @@ RetryOperation.prototype.attempt = function(fn, timeoutOps) {
       self._operationTimeoutCb();
     }, self._operationTimeout);
   }
+
+  this._operationStart = Date.now();
 
   this._fn(this._attempts);
 };

--- a/test/integration/test-retry-operation.js
+++ b/test/integration/test-retry-operation.js
@@ -205,7 +205,7 @@ var retry = require(common.dir.lib + '/retry');
         var curTime = new Date().getTime();
         longAsyncFunction(maxRetryTime - (curTime - startTime - 1), function(){
           if (operation.retry(error)) {
-            assert.fail('timeout should be occured');
+            assert.fail('timeout should be occurred');
             return;
           }
 

--- a/test/integration/test-retry-operation.js
+++ b/test/integration/test-retry-operation.js
@@ -192,7 +192,7 @@ var retry = require(common.dir.lib + '/retry');
   };
 
   var fn = function() {
-    var startTime = Date.now();
+    var startTime = new Date().getTime();
     operation.attempt(function(currentAttempt) {
       attempts++;
       assert.equal(currentAttempt, attempts);
@@ -202,7 +202,8 @@ var retry = require(common.dir.lib + '/retry');
             return;
         }
       } else {
-        longAsyncFunction(maxRetryTime - (Date.now() - startTime - 1), function(){
+        var curTime = new Date().getTime();
+        longAsyncFunction(maxRetryTime - (curTime - startTime - 1), function(){
           if (operation.retry(error)) {
             assert.fail('timeout should be occured');
             return;

--- a/test/integration/test-retry-operation.js
+++ b/test/integration/test-retry-operation.js
@@ -132,7 +132,7 @@ var retry = require(common.dir.lib + '/retry');
       var endTime = new Date().getTime();
       var minTime = startTime + (delay * 3);
       var maxTime = minTime + 20 // add a little headroom for code execution time
-      assert(endTime > minTime)
+      assert(endTime >= minTime)
       assert(endTime < maxTime)
       assert.strictEqual(attempts, 4);
       assert.strictEqual(operation.attempts(), attempts);


### PR DESCRIPTION
Sometimes operation can runs  long time. I want to limit maximum time for all tries.

`maxRetryTime` - The number of milliseconds maximum amount to retry the operation. Default is `Infinity`.