### PR TITLE
Avoid infinite loop and patch exponential backoff edge case

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -3,7 +3,7 @@ var RetryOperation = require('./retry_operation');
 exports.operation = function(options) {
   var timeouts = exports.timeouts(options);
   return new RetryOperation(timeouts, {
-      forever: options && options.forever,
+      forever: options && (options.forever || options.retries === Infinity),
       unref: options && options.unref,
       maxRetryTime: options && options.maxRetryTime
   });

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -51,7 +51,7 @@ exports.createTimeout = function(attempt, opts) {
     ? (Math.random() + 1)
     : 1;
 
-  var timeout = Math.round(random * opts.minTimeout * Math.pow(opts.factor, attempt));
+  var timeout = Math.round(random * Math.max(opts.minTimeout, 1) * Math.pow(opts.factor, attempt));
   timeout = Math.min(timeout, opts.maxTimeout);
 
   return timeout;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "retry",
   "description": "Abstraction for exponential and custom retry strategies for failed operations.",
   "license": "MIT",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "homepage": "https://github.com/tim-kos/node-retry",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This changes a few snags I hit as a noob to the API that I figured I'd toss up as a PR:

- Make exponential backoff not degrade to a sum when minTimeout is <= 0
- Auto-switch to forever mode when retries is Infinity.  This is still problematic for the timeouts method but at least it patches the primary use-case.

I hope I got the version change right, let me know if you need anything else, thanks!