### PR TITLE
Add a whitelist to avoid publishing unwanted files in the registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "git://github.com/tim-kos/node-retry.git"
   },
+  "files": ["lib", "example"],
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
Add the "files" field in the package.json to avoid publishing unwanted files in the registry. Files like
- gitignore
- travis.yml
- equation.gif
- Makefile (which seem to be used to release the package instead of npm scripts)

More information on the whitelist field here: https://docs.npmjs.com/files/package.json#files