### PR TITLE
Fixes retry so that _errors only keeps the last record rather than all but the last.

### DIFF
--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -60,7 +60,7 @@ RetryOperation.prototype.retry = function(err) {
   if (timeout === undefined) {
     if (this._cachedTimeouts) {
       // retry forever, only keep last error
-      this._errors.splice(this._errors.length - 1, this._errors.length);
+      this._errors.splice(0, this._errors.length - 1);
       this._timeouts = this._cachedTimeouts.slice(0);
       timeout = this._timeouts.shift();
     } else {


### PR DESCRIPTION
Fixed the slice operation so that this comment is true:
```
// retry forever, only keep last error
```