### PR TITLE
fixed retryOperation.reset()

### DIFF
--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -25,7 +25,7 @@ module.exports = RetryOperation;
 
 RetryOperation.prototype.reset = function() {
   this._attempts = 1;
-  this._timeouts = this._originalTimeouts;
+  this._timeouts = this._originalTimeouts.slice();
 }
 
 RetryOperation.prototype.stop = function() {

--- a/lib/retry_operation.js
+++ b/lib/retry_operation.js
@@ -61,8 +61,7 @@ RetryOperation.prototype.retry = function(err) {
     if (this._cachedTimeouts) {
       // retry forever, only keep last error
       this._errors.splice(0, this._errors.length - 1);
-      this._timeouts = this._cachedTimeouts.slice(0);
-      timeout = this._timeouts.shift();
+      timeout = this._cachedTimeouts.slice(-1);
     } else {
       return false;
     }


### PR DESCRIPTION
# The problem:
`retryOperation.reset()` is not resetting properly.

## Context
According to the documentation, `retryOperation.reset()` is supposed to:
```
Resets the internal state of the operation object, 
so that you can call attempt() again as if this was a new operation object.
```

The way `node-retry` works is by creating an array with a length of `n`, where `n` is the number of retries.
This array is stored in two variables, `this._originalTimeouts` and `this._timeouts`.
Each element in this array, is the interval (in milliseconds) in-between each retry/attempt.
The `n-th` attempt is initialized in `this._attempts = 1;`.

For each retry/attempt, `this._attempts` is increased by `1`, and `this._timeouts` is `.shift()`'ed.

When `retryOperation.reset()` is called, `this._attempts` is reverted back to `1`, and `this._timeouts` is restored by referencing `this._originalTimeouts`.
```
RetryOperation.prototype.reset = function() {
  this._attempts = 1;
  this._timeouts = this._originalTimeouts;
}
```
**Arrays in Javascript are mutable, which means `this._timeouts = this._originalTimeouts;` does not make a new copy of `this._originalTimeouts` into `this._timeouts`. Therefore, when `this._timeouts` is `.shift()`'ed, `this._originalTimeouts` also gets `.shift()`'ed, resulting in the loss of the intervals in `this._originalTimeouts`.**

## The solution
Make a new copy of `this._originalTimeouts` and *then* assign it to `this._timeouts`.

Before
```
RetryOperation.prototype.reset = function() {
  this._attempts = 1;
  this._timeouts = this._originalTimeouts;
}
```
After
```
RetryOperation.prototype.reset = function() {
  this._attempts = 1;
  this._timeouts = this._originalTimeouts.slice(); // <- .slice() returns a new copy
}
```
## Reference
Read more about `.shift()` [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift)
Read more about `.slice()` [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice)
Read more about **mutable** [here](https://developer.mozilla.org/en-US/docs/Glossary/Mutable)