### PR TITLE
Support options.retries Infintiy

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -1,11 +1,16 @@
 var RetryOperation = require('./retry_operation');
 
 exports.operation = function(options) {
+  if (options) {
+    options.forever = options && (options.forever || options.retries === Infinity);
+    options.retries = options && (options.forever ? undefined : options.retries);
+  }
+
   var timeouts = exports.timeouts(options);
   return new RetryOperation(timeouts, {
-      forever: options && (options.forever || options.retries === Infinity),
-      unref: options && options.unref,
-      maxRetryTime: options && options.maxRetryTime
+    forever: options && options.forever,
+    unref: options && options.unref,
+    maxRetryTime: options && options.maxRetryTime
   });
 };
 
@@ -22,7 +27,9 @@ exports.timeouts = function(options) {
     randomize: false
   };
   for (var key in options) {
-    opts[key] = options[key];
+    if (options[key]) {
+      opts[key] = options[key];
+    }
   }
 
   if (opts.minTimeout > opts.maxTimeout) {

--- a/test/integration/test-forever.js
+++ b/test/integration/test-forever.js
@@ -22,3 +22,19 @@ var retry = require(common.dir.lib + '/retry');
     }
   });
 })();
+
+(function testRetriesInfinity() {
+  const operation = retry.operation({
+    retries: Infinity,
+    minTimeout: 100,
+    maxTimeout: 100,
+  });
+
+  operation.attempt(function (numAttempt) {
+    if (numAttempt == 10) {
+      operation.stop();
+    }
+
+    operation.retry(new Error('foo'));
+  });
+})();


### PR DESCRIPTION
I bumped into a problem where when passing `Infinity` as an value for the `retries` option, it will result into a memory heap overload when it tries to [create the array of timeouts](https://github.com/tim-kos/node-retry/blob/a7cedfbaf58a774340e66d3ad2973b0cc191af89/lib/retry.js#L33). It seems like this option is [supposed to be supported](https://github.com/tim-kos/node-retry/blob/a7cedfbaf58a774340e66d3ad2973b0cc191af89/lib/retry.js#L6). This PR is my proposition on how this could be fixed.