### PR TITLE
using proper scope for createTimeout

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -31,11 +31,11 @@ exports.timeouts = function(options) {
 
   var timeouts = [];
   for (var i = 0; i < opts.retries; i++) {
-    timeouts.push(this.createTimeout(i, opts));
+    timeouts.push(exports.createTimeout(i, opts));
   }
 
   if (options && options.forever && !timeouts.length) {
-    timeouts.push(this.createTimeout(i, opts));
+    timeouts.push(exports.createTimeout(i, opts));
   }
 
   // sort the array numerically ascending


### PR DESCRIPTION
Using a proper scope to prevent errors with external bundlers

#### Why
I tried using [node-retry](https://github.com/tim-kos/node-retry) with [Parcel v2](https://parceljs.org/) it had a hard time finding the right module to map. Now when I ran the built code I got the following error:
```
TypeError: this.createTimeout is not a function
```
Using `exports.*` scope instead of `this.*` will prevent this error.